### PR TITLE
Support decoding non-standard (but common) <i8> tags

### DIFF
--- a/lib/src/converter.dart
+++ b/lib/src/converter.dart
@@ -39,7 +39,7 @@ class IntDecoder extends Decoder<int> {
   @override
   bool accept(XmlNode element) =>
       element is XmlElement &&
-      (element.name.local == 'int' || element.name.local == 'i4');
+      (element.name.local == 'int' || element.name.local == 'i4' || element.name.local == 'i8');
 }
 
 class BoolEncoder extends Encoder<bool> {


### PR DESCRIPTION
Hi @a14n,

First of all: thanks a lot for this package!  Very easy to use and to dive into.

I am suggesting this change since I encountered this while testing it:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<methodResponse>
<params>
<param><value><i8>1</i8></value></param>
</params>
</methodResponse>
```

While `<i8>` tags are not in the specification, they are supported by xmlrpc-c as well as Apache ws-xmlrpc. So this could be a common show-stopper when using this package.

As far as I understand, decoding 64-bit integers should not be an issue for either versions of Dart.