### PR TITLE
null safety migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+
+## 0.4.0-nullsafety.0 (2021-01-29)
+
+- Migrate to null safe dart
+- Only Uri accepted as url parameter on client to mimic change by `package:http`. Call `Uri.parse(url)` if you previously passed in a string 
+
 ## 0.3.0 (2020-05-11)
 
 - Add server support

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A simple usage example:
 import 'package:xml_rpc/client.dart' as xml_rpc;
 
 main() {
-  final url = '...';
+  final url = Uri.parse('...');
   xml_rpc
       .call(url, 'examples.getStateName', [41])
       .then((result) => print(result))

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,1 @@
 include: package:pedantic/analysis_options.yaml
-analyzer:
-  strong-mode:
-    implicit-casts: false

--- a/example/main.dart
+++ b/example/main.dart
@@ -4,7 +4,7 @@
 import 'package:xml_rpc/client.dart' as xml_rpc;
 
 void main() async {
-  const url = 'https://api.flickr.com/services/xmlrpc';
+  final url = Uri.parse('https://api.flickr.com/services/xmlrpc');
   try {
     var result = await xml_rpc.call(
       url,

--- a/example/server.dart
+++ b/example/server.dart
@@ -15,7 +15,7 @@ void main() async {
   try {
     print('calling service');
     var result = await client.call(
-      'http://localhost:$port',
+      Uri.parse('http://localhost:$port'),
       'hello',
       [
         {'api_key': 'yourApiKey'}

--- a/example/server_extension.dart
+++ b/example/server_extension.dart
@@ -1,3 +1,4 @@
+import 'package:pedantic/pedantic.dart';
 import 'package:xml_rpc/client.dart' as client;
 import 'package:xml_rpc/simple_server.dart' as server;
 import 'package:xml_rpc/src/converter_extension.dart';
@@ -5,7 +6,7 @@ import 'package:xml_rpc/src/converter_extension.dart';
 const port = 8080;
 const url = '127.0.0.1';
 
-final clientURI = 'http://localhost:$port';
+final clientURI = Uri.parse('http://localhost:$port');
 void main() async {
   final s = server.SimpleXmlRpcServer(
       host: url, port: port, handler: MyXmlRpcHandler());
@@ -15,8 +16,8 @@ void main() async {
   await callService();
 
   // Asyncronous calls to the service
-  callService();
-  callService();
+  unawaited(callService());
+  unawaited(callService());
   await Future.delayed(Duration(milliseconds: 10));
 
   try {
@@ -64,7 +65,7 @@ void main() async {
   await s.stop();
 }
 
-void callService() async {
+Future<void> callService() async {
   print('calling service');
   var result = await client.call(
     clientURI,

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -8,13 +8,14 @@
 /// You can make method calls with:
 ///
 ///     import 'package:xml_rpc/client.dart' as xml_rpc;
-///     main() {
-///       final url = '...';
-///       xml_rpc
-///           .call(url, 'examples.getStateName', [41])
-///           .then((result) => print(result))
-///           .catchError((error) => print(error));
+///     main() async {
+///       final url = Uri.parse('...');
+///       try {
+///         final result = await xml_rpc.call(url, 'examples.getStateName', [41]);
+///         print(result);
+///       } catch (error) {
+///         print(error);
+///       }
 ///     }
-
 export 'src/client.dart' show call, Fault, Base64Value, HttpPost;
 export 'src/converter.dart' hide getValueContent, encode, decode;

--- a/lib/client_c.dart
+++ b/lib/client_c.dart
@@ -34,13 +34,13 @@ final _codecs = List<Codec>.unmodifiable(<Codec>[
 ]);
 
 Future call(
-  dynamic url,
+  Uri url,
   String methodName,
   List params, {
-  Map<String, String> headers,
+  Map<String, String>? headers,
   Encoding encoding = utf8,
-  @Deprecated('Use httpPost parameter with client.post') http.Client client,
-  xml_rpc.HttpPost httpPost,
+  @Deprecated('Use httpPost parameter with client.post') http.Client? client,
+  xml_rpc.HttpPost? httpPost,
 }) =>
     xml_rpc.call(
       url,

--- a/lib/client_c.dart
+++ b/lib/client_c.dart
@@ -8,18 +8,17 @@
 /// You can make method calls with:
 ///
 ///     import 'package:xml_rpc/client_c.dart' as xml_rpc;
-///     main() {
-///       final url = '...';
-///       xml_rpc
-///           .call(url, 'examples.getStateName', [41])
-///           .then((result) => print(result))
-///           .catchError((error) => print(error));
+///     main() async {
+///       final url = Uri.parse('...');
+///       try {
+///         final result = await xml_rpc.call(url, 'examples.getStateName', [41]);
+///         print(result);
+///       } catch (error) {
+///         print(error);
+///       }
 ///     }
-
 import 'dart:async';
 import 'dart:convert' show Encoding, utf8;
-
-import 'package:http/http.dart' as http show Client;
 
 import 'client.dart' as xml_rpc show call, HttpPost;
 import 'src/converter.dart';
@@ -39,7 +38,6 @@ Future call(
   List params, {
   Map<String, String>? headers,
   Encoding encoding = utf8,
-  @Deprecated('Use httpPost parameter with client.post') http.Client? client,
   xml_rpc.HttpPost? httpPost,
 }) =>
     xml_rpc.call(
@@ -48,7 +46,6 @@ Future call(
       params,
       headers: headers,
       encoding: encoding,
-      client: client, // ignore: deprecated_member_use_from_same_package
       httpPost: httpPost,
       encodeCodecs: _codecs,
       decodeCodecs: _codecs,

--- a/lib/server.dart
+++ b/lib/server.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 
-import 'package:meta/meta.dart';
 import 'package:xml/xml.dart';
 
 import 'src/common.dart';
@@ -14,8 +13,8 @@ class XmlRpcHandler {
   ///
   /// It uses the specified set of [codecs] for encoding and decoding.
   XmlRpcHandler({
-    @required this.methods,
-    List<Codec> codecs,
+    required this.methods,
+    List<Codec>? codecs,
   }) : codecs = codecs ?? standardCodecs;
 
   /// The [codecs] used for encoding and decoding
@@ -27,7 +26,7 @@ class XmlRpcHandler {
   /// Marshalls the [data] from XML to Dart types, and then dispatches the function, and marshals the return value back into the XMLRPC format
   Future<XmlDocument> handle(XmlDocument document) async {
     String methodName;
-    final params = <Object>[];
+    final params = <Object?>[];
     try {
       final methodCall = document.findElements('methodCall').first;
       methodName = methodCall.findElements('methodName').first.text;
@@ -50,9 +49,9 @@ class XmlRpcHandler {
     }
 
     // execute call
-    Object result;
+    Object? result;
     try {
-      result = await Function.apply(methods[methodName], params);
+      result = await Function.apply(methods[methodName]!, params);
     } catch (e) {
       throw XmlRpcCallException(e);
     }
@@ -76,7 +75,7 @@ class XmlRpcHandler {
     ]);
   }
 
-  XmlDocument handleFault(Fault fault, {List<Codec> codecs}) => XmlDocument([
+  XmlDocument handleFault(Fault fault, {List<Codec>? codecs}) => XmlDocument([
         XmlProcessing('xml', 'version="1.0"'),
         XmlElement(XmlName('methodResponse'), [], [
           XmlElement(XmlName('fault'), [], [
@@ -92,11 +91,11 @@ abstract class XmlRpcException implements Exception {
   XmlRpcException([this.cause]);
 
   /// The cause thrown when the real method was called.
-  Object cause;
+  Object? cause;
 }
 
 class XmlRpcRequestFormatException extends XmlRpcException {
-  XmlRpcRequestFormatException([Object cause]) : super(cause);
+  XmlRpcRequestFormatException([Object? cause]) : super(cause);
 }
 
 /// When an exception occurs in the real method call
@@ -109,10 +108,10 @@ class XmlRpcMethodNotFoundException extends XmlRpcException {
 
 /// When an exception occurs in the real method call
 class XmlRpcCallException extends XmlRpcException {
-  XmlRpcCallException([Object cause]) : super(cause);
+  XmlRpcCallException([Object? cause]) : super(cause);
 }
 
 /// When an exception occurs in response encoding
 class XmlRpcResponseEncodingException extends XmlRpcException {
-  XmlRpcResponseEncodingException([Object cause]) : super(cause);
+  XmlRpcResponseEncodingException([Object? cause]) : super(cause);
 }

--- a/lib/simple_server.dart
+++ b/lib/simple_server.dart
@@ -12,13 +12,13 @@ export 'server.dart';
 /// A [XmlRpcServer] that handles the XMLRPC server protocol with a single threaded [HttpServer]
 class SimpleXmlRpcServer extends XmlRpcServer {
   /// The [HttpServer] used for handling responses
-  HttpServer _httpServer;
+  late HttpServer _httpServer;
 
   /// Creates a [SimpleXmlRpcServer]
   SimpleXmlRpcServer({
-    @required String host,
-    @required int port,
-    @required XmlRpcHandler handler,
+    required String host,
+    required int port,
+    required XmlRpcHandler handler,
     Encoding encoding = utf8,
   }) : super(host: host, port: port, handler: handler, encoding: encoding);
 
@@ -65,9 +65,9 @@ abstract class XmlRpcServer {
   /// You must await the call to [serverForever] to start up the server
   /// before making any client requests
   XmlRpcServer({
-    @required this.host,
-    @required this.port,
-    @required this.handler,
+    required this.host,
+    required this.port,
+    required this.handler,
     this.encoding = utf8,
   });
 
@@ -92,7 +92,7 @@ abstract class XmlRpcServer {
     }
     try {
       final xmlRpcRequest = await encoding.decodeStream(request);
-      final response = await handler.handle(parse(xmlRpcRequest));
+      final response = await handler.handle(XmlDocument.parse(xmlRpcRequest));
       await _sendResponse(httpResponse, response);
     } on XmlRpcRequestFormatException {
       await _sendResponse(httpResponse,

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -17,23 +17,23 @@ export 'common.dart';
 
 /// The function to make http post.
 typedef HttpPost = Future<http.Response> Function(
-  dynamic url, {
-  Map<String, String> headers,
+  Uri url, {
+  Map<String, String>? headers,
   dynamic body,
-  Encoding encoding,
+  Encoding? encoding,
 });
 
 /// Make a xmlrpc call to the given [url], which can be a [Uri] or a [String].
 Future call(
-  dynamic url,
+  Uri url,
   String methodName,
   List params, {
-  Map<String, String> headers,
+  Map<String, String>? headers,
   Encoding encoding = utf8,
-  @Deprecated('Use httpPost parameter with client.post') http.Client client,
-  HttpPost httpPost,
-  List<Codec> encodeCodecs,
-  List<Codec> decodeCodecs,
+  @Deprecated('Use httpPost parameter with client.post') http.Client? client,
+  HttpPost? httpPost,
+  List<Codec>? encodeCodecs,
+  List<Codec>? decodeCodecs,
 }) async {
   encodeCodecs ??= standardCodecs;
   decodeCodecs ??= standardCodecs;
@@ -45,12 +45,12 @@ Future call(
     if (headers != null) ...headers,
   };
 
-  final post = httpPost ?? (client != null ? client.post : http.post);
+  final HttpPost post = httpPost ?? (client != null ? client.post : http.post);
   final response =
       await post(url, headers: _headers, body: xml, encoding: encoding);
   if (response.statusCode != 200) throw response;
   final body = response.body;
-  final value = decodeResponse(parse(body), decodeCodecs);
+  final value = decodeResponse(XmlDocument.parse(body), decodeCodecs);
   if (value is Fault) {
     throw value;
   } else {
@@ -62,7 +62,7 @@ XmlDocument convertMethodCall(
     String methodName, List params, List<Codec> encodeCodecs) {
   final methodCallChildren = [
     XmlElement(XmlName('methodName'), [], [XmlText(methodName)]),
-    if (params != null && params.isNotEmpty)
+    if (params.isNotEmpty)
       XmlElement(
         XmlName('params'),
         [],
@@ -93,8 +93,8 @@ dynamic decodeResponse(XmlDocument document, List<Codec> decodeCodecs) {
     final elt = getValueContent(valueElt);
     return decode(elt, decodeCodecs);
   } else {
-    int faultCode;
-    String faultString;
+    int? faultCode;
+    String? faultString;
     final members = responseElt
         .findElements('fault')
         .first

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -7,7 +7,7 @@ library xml_rpc.src.client;
 import 'dart:async';
 import 'dart:convert' show Encoding, utf8;
 
-import 'package:http/http.dart' as http show post, Client, Response;
+import 'package:http/http.dart' as http show post, Response;
 import 'package:xml/xml.dart';
 
 import 'common.dart';
@@ -19,7 +19,7 @@ export 'common.dart';
 typedef HttpPost = Future<http.Response> Function(
   Uri url, {
   Map<String, String>? headers,
-  dynamic body,
+  Object? body,
   Encoding? encoding,
 });
 
@@ -30,7 +30,6 @@ Future call(
   List params, {
   Map<String, String>? headers,
   Encoding encoding = utf8,
-  @Deprecated('Use httpPost parameter with client.post') http.Client? client,
   HttpPost? httpPost,
   List<Codec>? encodeCodecs,
   List<Codec>? decodeCodecs,
@@ -45,7 +44,7 @@ Future call(
     if (headers != null) ...headers,
   };
 
-  final HttpPost post = httpPost ?? (client != null ? client.post : http.post);
+  final post = httpPost ?? http.post;
   final response =
       await post(url, headers: _headers, body: xml, encoding: encoding);
   if (response.statusCode != 200) throw response;
@@ -93,8 +92,8 @@ dynamic decodeResponse(XmlDocument document, List<Codec> decodeCodecs) {
     final elt = getValueContent(valueElt);
     return decode(elt, decodeCodecs);
   } else {
-    int? faultCode;
-    String? faultString;
+    late int faultCode;
+    late String faultString;
     final members = responseElt
         .findElements('fault')
         .first

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -7,10 +7,10 @@ import 'dart:convert' show base64;
 /// An object corresponding to a `<fault>` in the response.
 class Fault {
   /// The code contained in <faultCode>.
-  final int code;
+  final int? code;
 
   /// The text contained in <faultString>.
-  final String text;
+  final String? text;
 
   Fault(this.code, this.text);
 
@@ -27,13 +27,13 @@ class Fault {
 
 /// A container for a base64 encoded value.
 class Base64Value {
-  String _base64String;
-  List<int> _bytes;
+  String? _base64String;
+  List<int>? _bytes;
 
   Base64Value(this._bytes);
   Base64Value.fromBase64String(this._base64String);
 
-  String get base64String => _base64String ??= base64.encode(_bytes);
+  String get base64String => _base64String ??= base64.encode(_bytes!);
 
-  List<int> get bytes => _bytes ??= base64.decode(_base64String);
+  List<int> get bytes => _bytes ??= base64.decode(_base64String!);
 }

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -7,10 +7,10 @@ import 'dart:convert' show base64;
 /// An object corresponding to a `<fault>` in the response.
 class Fault {
   /// The code contained in <faultCode>.
-  final int? code;
+  final int code;
 
   /// The text contained in <faultString>.
-  final String? text;
+  final String text;
 
   Fault(this.code, this.text);
 

--- a/lib/src/converter.dart
+++ b/lib/src/converter.dart
@@ -2,7 +2,7 @@
 // source code is governed by a BSD-style license that can be found in the
 // LICENSE file.
 
-import 'package:meta/meta.dart';
+import 'package:collection/collection.dart';
 import 'package:xml/xml.dart';
 
 import 'common.dart';
@@ -17,41 +17,43 @@ final standardCodecs = List<Codec>.unmodifiable(<Codec>[
   structCodec,
   arrayCodec,
 ]);
+typedef XmlCodecDecodeSignature = Object? Function(XmlNode?);
+typedef XmlCodecEncodeSignature = XmlNode Function(Object?);
 
 abstract class Codec<T> {
-  T decode(XmlNode node, dynamic Function(XmlNode) decode);
-  XmlNode encode(value, XmlNode Function(dynamic) encode);
+  T decode(XmlNode? node, XmlCodecDecodeSignature? decode);
+  XmlNode encode(Object? value, XmlCodecEncodeSignature? encode);
 }
 
 class SimpleCodec<T> implements Codec<T> {
   SimpleCodec({
-    @required this.nodeLocalName,
-    @required this.encodeValue,
-    @required this.decodeValue,
+    required this.nodeLocalName,
+    required this.encodeValue,
+    required this.decodeValue,
   });
 
   final String nodeLocalName;
   final String Function(T value) encodeValue;
-  final T Function(String text) decodeValue;
+  final T Function(String text)? decodeValue;
 
   @override
-  XmlNode encode(value, XmlNode Function(dynamic) encode) {
+  XmlNode encode(Object? value, XmlCodecEncodeSignature? encode) {
     if (value is! T) throw ArgumentError();
 
     return XmlElement(
       XmlName(nodeLocalName),
       [],
-      [XmlText(encodeValue(value as T))],
+      [XmlText(encodeValue(value))],
     );
   }
 
   @override
-  T decode(XmlNode node, dynamic Function(XmlNode) decode) {
+  T decode(XmlNode? node, XmlCodecDecodeSignature? decode) {
     if (!(node is XmlElement && node.name.local == nodeLocalName)) {
       throw ArgumentError();
     }
 
-    return decodeValue(node.text);
+    return decodeValue!(node.text);
   }
 }
 
@@ -59,7 +61,7 @@ final intCodec = _IntCodec();
 
 class _IntCodec implements Codec<int> {
   @override
-  XmlNode encode(value, XmlNode Function(dynamic) encode) {
+  XmlNode encode(Object? value, XmlCodecEncodeSignature? encode) {
     if (!(value is int && value >= -2147483648 && value <= 2147483647)) {
       throw ArgumentError();
     }
@@ -72,7 +74,7 @@ class _IntCodec implements Codec<int> {
   }
 
   @override
-  int decode(XmlNode node, Function(XmlNode) decode) {
+  int decode(XmlNode? node, XmlCodecDecodeSignature? decode) {
     if (!(node is XmlElement && ['int', 'i4'].contains(node.name.local))) {
       throw ArgumentError();
     }
@@ -104,7 +106,7 @@ class _StringCodec extends SimpleCodec<String> {
         );
 
   @override
-  String decode(XmlNode node, Function(XmlNode) decode) {
+  String decode(XmlNode? node, XmlCodecDecodeSignature? decode) {
     if (!(node == null || // with empty String that leads to "<value />"
         node is XmlText ||
         node is XmlElement && node.name.local == 'string')) {
@@ -137,35 +139,35 @@ final faultCodec = _FaultCodec();
 
 class _FaultCodec implements Codec<Fault> {
   @override
-  XmlNode encode(value, XmlNode Function(dynamic) encode) {
+  XmlNode encode(Object? value, XmlCodecEncodeSignature? encode) {
     if (value is! Fault) throw ArgumentError();
 
     final members = <XmlNode>[];
-    final fault = value as Fault;
-    final faultMap = <String, dynamic>{
+    final fault = value;
+    final faultMap = <String, Object?>{
       'faultCode': fault.code,
       'faultString': fault.text
     };
     faultMap.forEach((k, v) {
       members.add(XmlElement(XmlName('member'), [], [
         XmlElement(XmlName('name'), [], [XmlText(k)]),
-        XmlElement(XmlName('value'), [], [encode(v)])
+        XmlElement(XmlName('value'), [], [encode!(v)])
       ]));
     });
     return XmlElement(XmlName('struct'), [], members);
   }
 
   @override
-  Fault decode(XmlNode node, Function(XmlNode) decode) {
+  Fault decode(XmlNode? node, XmlCodecDecodeSignature? decode) {
     if (!(node is XmlElement && node.name.local == 'struct')) {
       throw ArgumentError();
     }
-    final struct = <String, dynamic>{};
-    for (final member in (node as XmlElement).findElements('member')) {
+    final struct = <String, Object?>{};
+    for (final member in node.findElements('member')) {
       final name = member.findElements('name').first.text;
       final valueElt = member.findElements('value').first;
       final elt = getValueContent(valueElt);
-      struct[name] = decode(elt);
+      struct[name] = decode!(elt);
     }
     if (!struct.containsKey('faultCode') ||
         struct['faultCode'] is! int ||
@@ -173,7 +175,7 @@ class _FaultCodec implements Codec<Fault> {
         struct['faultString'] is! String) {
       throw StateError('$struct is not a properly encoded Fault');
     }
-    return Fault(struct['faultCode'] as int, struct['faultString'] as String);
+    return Fault(struct['faultCode'] as int?, struct['faultString'] as String?);
   }
 }
 
@@ -181,31 +183,31 @@ final structCodec = _StructCodec();
 
 class _StructCodec implements Codec<Map<String, dynamic>> {
   @override
-  XmlNode encode(value, XmlNode Function(dynamic) encode) {
-    if (value is! Map<String, dynamic>) throw ArgumentError();
+  XmlNode encode(Object? value, XmlCodecEncodeSignature? encode) {
+    if (value is! Map<String, Object?>) throw ArgumentError();
 
     final members = <XmlNode>[];
-    (value as Map<String, dynamic>).forEach((k, v) {
+    value.forEach((k, v) {
       members.add(XmlElement(XmlName('member'), [], [
         XmlElement(XmlName('name'), [], [XmlText(k)]),
-        XmlElement(XmlName('value'), [], [encode(v)])
+        XmlElement(XmlName('value'), [], [encode!(v)])
       ]));
     });
     return XmlElement(XmlName('struct'), [], members);
   }
 
   @override
-  Map<String, dynamic> decode(XmlNode node, Function(XmlNode) decode) {
+  Map<String, dynamic> decode(XmlNode? node, XmlCodecDecodeSignature? decode) {
     if (!(node is XmlElement && node.name.local == 'struct')) {
       throw ArgumentError();
     }
 
     final struct = <String, dynamic>{};
-    for (final member in (node as XmlElement).findElements('member')) {
+    for (final member in node.findElements('member')) {
       final name = member.findElements('name').first.text;
       final valueElt = member.findElements('value').first;
       final elt = getValueContent(valueElt);
-      struct[name] = decode(elt);
+      struct[name] = decode!(elt);
     }
     return struct;
   }
@@ -215,37 +217,38 @@ final arrayCodec = _ArrayCodec();
 
 class _ArrayCodec implements Codec<List> {
   @override
-  XmlNode encode(value, XmlNode Function(dynamic) encode) {
+  XmlNode encode(Object? value, XmlCodecEncodeSignature? encode) {
     if (value is! List) throw ArgumentError();
 
     final values = <XmlNode>[];
     value.forEach((e) {
-      values.add(XmlElement(XmlName('value'), [], [encode(e)]));
+      values.add(XmlElement(XmlName('value'), [], [encode!(e)]));
     });
     final data = XmlElement(XmlName('data'), [], values);
     return XmlElement(XmlName('array'), [], [data]);
   }
 
   @override
-  List decode(XmlNode node, Function(XmlNode) decode) {
+  List decode(XmlNode? node, XmlCodecDecodeSignature? decode) {
     if (!(node is XmlElement && node.name.local == 'array')) {
       throw ArgumentError();
     }
 
-    return (node as XmlElement)
+    return node
         .findElements('data')
         .first
         .findElements('value')
         .map(getValueContent)
-        .map(decode)
+        .map((value) => decode?.call(value))
         .toList();
   }
 }
 
-XmlNode getValueContent(XmlElement valueElt) => valueElt.children
-    .firstWhere((e) => e is XmlElement, orElse: () => valueElt.firstChild);
+XmlNode? getValueContent(XmlElement valueElt) =>
+    valueElt.children.firstWhereOrNull((e) => e is XmlElement) ??
+    valueElt.firstChild;
 
-XmlNode encode(value, List<Codec> codecs) {
+XmlNode encode(Object? value, List<Codec<Object?>> codecs) {
   for (final codec in codecs) {
     try {
       return codec.encode(value, (v) => encode(v, codecs));
@@ -256,7 +259,7 @@ XmlNode encode(value, List<Codec> codecs) {
   throw ArgumentError('No encoder to encode the value');
 }
 
-dynamic decode(XmlNode node, List<Codec> codecs) {
+Object? decode(XmlNode? node, List<Codec<Object?>> codecs) {
   for (final codec in codecs) {
     try {
       return codec.decode(node, (v) => decode(v, codecs));

--- a/lib/src/converter.dart
+++ b/lib/src/converter.dart
@@ -143,10 +143,9 @@ class _FaultCodec implements Codec<Fault> {
     if (value is! Fault) throw ArgumentError();
 
     final members = <XmlNode>[];
-    final fault = value;
     final faultMap = <String, Object?>{
-      'faultCode': fault.code,
-      'faultString': fault.text
+      'faultCode': value.code,
+      'faultString': value.text
     };
     faultMap.forEach((k, v) {
       members.add(XmlElement(XmlName('member'), [], [
@@ -169,13 +168,12 @@ class _FaultCodec implements Codec<Fault> {
       final elt = getValueContent(valueElt);
       struct[name] = decode!(elt);
     }
-    if (!struct.containsKey('faultCode') ||
-        struct['faultCode'] is! int ||
-        !struct.containsKey('faultString') ||
-        struct['faultString'] is! String) {
+    final faultCode = struct['faultCode'];
+    final faultString = struct['faultString'];
+    if (faultCode is! int || faultString is! String) {
       throw StateError('$struct is not a properly encoded Fault');
     }
-    return Fault(struct['faultCode'] as int?, struct['faultString'] as String?);
+    return Fault(faultCode, faultString);
   }
 }
 

--- a/lib/src/converter_extension.dart
+++ b/lib/src/converter_extension.dart
@@ -16,14 +16,14 @@ final nilCodec = _NilCodec();
 
 class _NilCodec implements Codec<Null> {
   @override
-  XmlNode encode(value, XmlNode Function(dynamic) encode) {
+  XmlNode encode(Object? value, XmlCodecEncodeSignature? encode) {
     if (value != null) throw ArgumentError();
 
     return XmlElement(XmlName('nil'));
   }
 
   @override
-  Null decode(XmlNode node, Function(XmlNode) decode) {
+  Null decode(XmlNode? node, XmlCodecDecodeSignature? decode) {
     if (!(node is XmlElement && node.name.local == 'nil')) {
       throw ArgumentError();
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: xml_rpc
-version: 0.3.0
+version: 0.4.0-nullsafety.0
 description: >
   A library implementing the XML-RPC protocol.
   It provides a client allowing to make calls to servers.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,11 +5,11 @@ description: >
   It provides a client allowing to make calls to servers.
 homepage: https://github.com/a14n/dart-xmlrpc
 environment:
-  sdk: ">=2.2.2 <3.0.0"
+  sdk: '>=2.12.0-0 <3.0.0'
 dependencies:
-  http: ^0.12.1
-  meta: ^1.1.8
-  xml: ^4.1.0
+  http: ^0.13.0-nullsafety.0 
+  collection: ^1.15.0-nullsafety.5
+  xml: ^5.0.0-nullsafety.1
 dev_dependencies:
   test: ^1.14.3
   pedantic: ^1.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/a14n/dart-xmlrpc
 environment:
   sdk: '>=2.12.0-0 <3.0.0'
 dependencies:
-  http: ^0.13.0-nullsafety.0 
+  http: ^0.13.0-nullsafety.0
   collection: ^1.15.0-nullsafety.5
   xml: ^5.0.0-nullsafety.1
 dev_dependencies:

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -13,7 +13,7 @@ import 'package:test/test.dart';
 import 'package:xml_rpc/client.dart';
 
 void main() {
-  HttpServer httpServer;
+  late HttpServer httpServer;
 
   setUp(() => startServer(9000).then((e) => httpServer = e));
   tearDown(() => httpServer.close(force: true));
@@ -39,7 +39,7 @@ void main() {
         r.response.close();
       }));
     }));
-    call('http://localhost:${httpServer.port}', 'm1', [])
+    call(Uri.parse('http://localhost:${httpServer.port}'), 'm1', [])
         .then(expectAsync1((e) {
       expect(e, equals('South Dakota'));
     }));
@@ -48,7 +48,7 @@ void main() {
   test('Specify encoding', () {
     httpServer.listen(expectAsync1((r) {
       expect(r.headers.contentLength, isNotNull);
-      expect(r.headers.contentType.charset, equals('iso-8859-1'));
+      expect(r.headers.contentType!.charset, equals('iso-8859-1'));
       expect(r.method, equals('POST'));
       latin1.decodeStream(r).then(expectAsync1((body) {
         expect(
@@ -67,7 +67,8 @@ void main() {
         r.response.close();
       }));
     }));
-    call('http://localhost:${httpServer.port}', 'éà', [], encoding: latin1)
+    call(Uri.parse('http://localhost:${httpServer.port}'), 'éà', [],
+            encoding: latin1)
         .then(expectAsync1((e) {
       expect(e, equals('éçàù'));
     }));
@@ -75,8 +76,8 @@ void main() {
 
   test('Call with error', () {
     httpServer.listen((_) => httpServer.close(force: true));
-    call('http://localhost:${httpServer.port}', 'm1', [1])
-        .catchError(expectAsync1((e) {
+    call(Uri.parse('http://localhost:${httpServer.port}'), 'm1', [1])
+        .catchError(expectAsync1((dynamic e) {
       expect(e, const TypeMatcher<ClientException>());
     }));
   });

--- a/test/src/client_test.dart
+++ b/test/src/client_test.dart
@@ -5,7 +5,7 @@
 library xml_rpc.src.client.test;
 
 import 'package:test/test.dart';
-import 'package:xml/xml.dart' show parse;
+import 'package:xml/xml.dart' show XmlDocument;
 import 'package:xml_rpc/src/client.dart';
 import 'package:xml_rpc/src/converter.dart';
 
@@ -65,7 +65,7 @@ void main() {
 
   group('decodeResponse', () {
     test('for simple response', () {
-      expect(decodeResponse(parse('''
+      expect(decodeResponse(XmlDocument.parse('''
 <?xml version="1.0"?>
 <methodResponse>
   <params>
@@ -77,7 +77,7 @@ void main() {
     });
 
     test('for fault', () {
-      var result = decodeResponse(parse('''
+      var result = decodeResponse(XmlDocument.parse('''
 <?xml version="1.0"?>
 <methodResponse>
   <fault>

--- a/test/src/converter_extension_test.dart
+++ b/test/src/converter_extension_test.dart
@@ -15,12 +15,12 @@ void main() {
     });
 
     test('decode <nil></nil>', () {
-      final elt = parse('<nil></nil>').firstChild;
+      final elt = XmlDocument.parse('<nil></nil>').firstChild;
       expect(nilCodec.decode(elt, null), equals(null));
     });
 
     test('decode <nil/>', () {
-      final elt = parse('<nil/>').firstChild;
+      final elt = XmlDocument.parse('<nil/>').firstChild;
       expect(nilCodec.decode(elt, null), equals(null));
     });
   });
@@ -42,12 +42,12 @@ void main() {
     });
 
     test('decode <i8>1</i8>', () {
-      final elt = parse('<i8>1</i8>').firstChild;
+      final elt = XmlDocument.parse('<i8>1</i8>').firstChild;
       expect(i8Codec.decode(elt, null), equals(1));
     });
 
     test('decode <i8>2147483648</i8>', () {
-      final elt = parse('<i8>2147483648</i8>').firstChild;
+      final elt = XmlDocument.parse('<i8>2147483648</i8>').firstChild;
       expect(i8Codec.decode(elt, null), equals(2147483648));
     });
   });

--- a/test/src/converter_test.dart
+++ b/test/src/converter_test.dart
@@ -8,7 +8,6 @@ import 'package:test/test.dart';
 import 'package:xml/xml.dart';
 import 'package:xml_rpc/src/common.dart';
 import 'package:xml_rpc/src/converter.dart';
-import 'package:xml_rpc/src/converter_extension.dart';
 
 void main() {
   group('intCodec', () {
@@ -190,29 +189,6 @@ void main() {
     <name>faultString</name>
     <value>
       <string>This is a bad fault</string>
-    </value>
-  </member>
-</struct>'''));
-    });
-
-    test('encode empty fault correctly with nil codec', () {
-      expect(
-          faultCodec
-              .encode(Fault(null, null),
-                  (n) => encode(n, [...standardCodecs, nilCodec]))
-              .toXmlString(pretty: true),
-          equals('''
-<struct>
-  <member>
-    <name>faultCode</name>
-    <value>
-      <nil/>
-    </value>
-  </member>
-  <member>
-    <name>faultString</name>
-    <value>
-      <nil/>
     </value>
   </member>
 </struct>'''));

--- a/test/src/converter_test.dart
+++ b/test/src/converter_test.dart
@@ -26,17 +26,17 @@ void main() {
     });
 
     test('decode <int>1</int>', () {
-      final elt = parse('<int>1</int>').firstChild;
+      final elt = XmlDocument.parse('<int>1</int>').firstChild;
       expect(intCodec.decode(elt, null), equals(1));
     });
 
     test('decode <i4>1</i4>', () {
-      final elt = parse('<i4>1</i4>').firstChild;
+      final elt = XmlDocument.parse('<i4>1</i4>').firstChild;
       expect(intCodec.decode(elt, null), equals(1));
     });
 
     test('throws for <string>1</string>', () {
-      final elt = parse('<string>1</string>').firstChild;
+      final elt = XmlDocument.parse('<string>1</string>').firstChild;
       expect(() => intCodec.decode(elt, null), throwsArgumentError);
     });
   });
@@ -53,22 +53,22 @@ void main() {
     });
 
     test('decode <boolean>1</boolean>', () {
-      final elt = parse('<boolean>1</boolean>').firstChild;
+      final elt = XmlDocument.parse('<boolean>1</boolean>').firstChild;
       expect(boolCodec.decode(elt, null), equals(true));
     });
 
     test('decode <boolean>0</boolean>', () {
-      final elt = parse('<boolean>0</boolean>').firstChild;
+      final elt = XmlDocument.parse('<boolean>0</boolean>').firstChild;
       expect(boolCodec.decode(elt, null), equals(false));
     });
 
     test('throws for <boolean>a</boolean>', () {
-      final elt = parse('<boolean>a</boolean>').firstChild;
+      final elt = XmlDocument.parse('<boolean>a</boolean>').firstChild;
       expect(() => boolCodec.decode(elt, null), throwsStateError);
     });
 
     test('throws for <string>1</string>', () {
-      final elt = parse('<string>1</string>').firstChild;
+      final elt = XmlDocument.parse('<string>1</string>').firstChild;
       expect(() => boolCodec.decode(elt, null), throwsArgumentError);
     });
   });
@@ -80,12 +80,12 @@ void main() {
     });
 
     test('decode <string>a</string>', () {
-      final elt = parse('<string>a</string>').firstChild;
+      final elt = XmlDocument.parse('<string>a</string>').firstChild;
       expect(stringCodec.decode(elt, null), equals('a'));
     });
 
     test('decode <string>abcde</string>', () {
-      final elt = parse('<string>abcde</string>').firstChild;
+      final elt = XmlDocument.parse('<string>abcde</string>').firstChild;
       expect(stringCodec.decode(elt, null), equals('abcde'));
     });
 
@@ -95,7 +95,7 @@ void main() {
     });
 
     test('throws for <int>1</int>', () {
-      final elt = parse('<boolean>a</boolean>').firstChild;
+      final elt = XmlDocument.parse('<boolean>a</boolean>').firstChild;
       expect(() => stringCodec.decode(elt, null), throwsArgumentError);
     });
   });
@@ -107,17 +107,17 @@ void main() {
     });
 
     test('decode <double>1.234</double>', () {
-      final elt = parse('<double>1.234</double>').firstChild;
+      final elt = XmlDocument.parse('<double>1.234</double>').firstChild;
       expect(doubleCodec.decode(elt, null), equals(1.234));
     });
 
     test('decode <double>1</double>', () {
-      final elt = parse('<double>1</double>').firstChild;
+      final elt = XmlDocument.parse('<double>1</double>').firstChild;
       expect(doubleCodec.decode(elt, null), equals(1));
     });
 
     test('throws for <string>1</string>', () {
-      final elt = parse('<string>1</string>').firstChild;
+      final elt = XmlDocument.parse('<string>1</string>').firstChild;
       expect(() => doubleCodec.decode(elt, null), throwsArgumentError);
     });
   });
@@ -133,22 +133,22 @@ void main() {
     });
 
     test('decode 2015-01-22T08:13:42.000Z', () {
-      final elt =
-          parse('<dateTime.iso8601>2015-01-22T08:13:42.000Z</dateTime.iso8601>')
-              .firstChild;
+      final elt = XmlDocument.parse(
+              '<dateTime.iso8601>2015-01-22T08:13:42.000Z</dateTime.iso8601>')
+          .firstChild;
       expect(dateTimeCodec.decode(elt, null),
           equals(DateTime.utc(2015, 1, 22, 8, 13, 42)));
     });
     test('decode 19980717T14:08:55', () {
-      final elt =
-          parse('<dateTime.iso8601>19980717T14:08:55</dateTime.iso8601>')
-              .firstChild;
+      final elt = XmlDocument.parse(
+              '<dateTime.iso8601>19980717T14:08:55</dateTime.iso8601>')
+          .firstChild;
       expect(dateTimeCodec.decode(elt, null),
           equals(DateTime(1998, 7, 17, 14, 8, 55)));
     });
 
     test('throws for <string>1</string>', () {
-      final elt = parse('<string>1</string>').firstChild;
+      final elt = XmlDocument.parse('<string>1</string>').firstChild;
       expect(() => dateTimeCodec.decode(elt, null), throwsArgumentError);
     });
   });
@@ -160,13 +160,13 @@ void main() {
     });
 
     test('decode AQID', () {
-      final elt = parse('<base64>AQID</base64>').firstChild;
+      final elt = XmlDocument.parse('<base64>AQID</base64>').firstChild;
       expect(base64Codec.decode(elt, null).base64String, equals('AQID'));
       expect(base64Codec.decode(elt, null).bytes, equals([1, 2, 3]));
     });
 
     test('throws for <string>1</string>', () {
-      final elt = parse('<string>1</string>').firstChild;
+      final elt = XmlDocument.parse('<string>1</string>').firstChild;
       expect(() => base64Codec.decode(elt, null), throwsArgumentError);
     });
   });
@@ -219,7 +219,7 @@ void main() {
     });
 
     test('decode fault', () {
-      final elt = parse('''
+      final elt = XmlDocument.parse('''
 <struct>
   <member>
     <name>faultCode</name>
@@ -239,7 +239,7 @@ void main() {
     });
 
     test('decode fault with empty string value', () {
-      final elt = parse('''
+      final elt = XmlDocument.parse('''
 <struct>
   <member>
     <name>faultCode</name>
@@ -257,7 +257,7 @@ void main() {
     });
 
     test('throws for <string>1</string>', () {
-      final elt = parse('<string>1</string>').firstChild;
+      final elt = XmlDocument.parse('<string>1</string>').firstChild;
       expect(() => structCodec.decode(elt, null), throwsArgumentError);
     });
   });
@@ -290,7 +290,7 @@ void main() {
     });
 
     test('decode struct', () {
-      final elt = parse('''
+      final elt = XmlDocument.parse('''
 <struct>
   <member>
     <name>a</name>
@@ -310,12 +310,12 @@ void main() {
     });
 
     test('decode empty struct', () {
-      final elt = parse('<struct></struct>').firstChild;
+      final elt = XmlDocument.parse('<struct></struct>').firstChild;
       expect(structCodec.decode(elt, null), equals({}));
     });
 
     test('decode struct with empty string value', () {
-      final elt = parse('''
+      final elt = XmlDocument.parse('''
 <struct>
   <member>
     <name />
@@ -333,7 +333,7 @@ void main() {
     });
 
     test('throws for <string>1</string>', () {
-      final elt = parse('<string>1</string>').firstChild;
+      final elt = XmlDocument.parse('<string>1</string>').firstChild;
       expect(() => structCodec.decode(elt, null), throwsArgumentError);
     });
   });
@@ -363,7 +363,7 @@ void main() {
     });
 
     test('decode array', () {
-      final elt = parse('''
+      final elt = XmlDocument.parse('''
 <array>
   <data>
     <value>
@@ -379,47 +379,47 @@ void main() {
     });
 
     test('decode empty array', () {
-      final elt = parse('<array><data /></array>').firstChild;
+      final elt = XmlDocument.parse('<array><data /></array>').firstChild;
       expect(arrayCodec.decode(elt, null), equals([]));
     });
 
     test('throws for <string>1</string>', () {
-      final elt = parse('<string>1</string>').firstChild;
+      final elt = XmlDocument.parse('<string>1</string>').firstChild;
       expect(() => arrayCodec.decode(elt, null), throwsArgumentError);
     });
   });
 
   group('decode method', () {
     test('should accept <int>', () {
-      final elt = parse('<int>123</int>').firstChild;
+      final elt = XmlDocument.parse('<int>123</int>').firstChild;
       expect(decode(elt, standardCodecs), equals(123));
     });
 
     test('should accept <i4>', () {
-      final elt = parse('<i4>4567</i4>').firstChild;
+      final elt = XmlDocument.parse('<i4>4567</i4>').firstChild;
       expect(decode(elt, standardCodecs), equals(4567));
     });
 
     test('should accept <boolean>', () {
-      final elt = parse('<boolean>1</boolean>').firstChild;
+      final elt = XmlDocument.parse('<boolean>1</boolean>').firstChild;
       expect(decode(elt, standardCodecs), equals(true));
     });
 
     test('should accept <double>', () {
-      final elt = parse('<double>1.45</double>').firstChild;
+      final elt = XmlDocument.parse('<double>1.45</double>').firstChild;
       expect(decode(elt, standardCodecs), equals(1.45));
     });
 
     test('should accept <dateTime.iso8601>', () {
-      final elt =
-          parse('<dateTime.iso8601>19980717T14:08:55</dateTime.iso8601>')
-              .firstChild;
+      final elt = XmlDocument.parse(
+              '<dateTime.iso8601>19980717T14:08:55</dateTime.iso8601>')
+          .firstChild;
       expect(decode(elt, standardCodecs),
           equals(DateTime(1998, 7, 17, 14, 8, 55)));
     });
 
     test('should accept <base64>', () {
-      final elt = parse('<base64>AQID</base64>').firstChild;
+      final elt = XmlDocument.parse('<base64>AQID</base64>').firstChild;
       expect(decode(elt, standardCodecs), const TypeMatcher<Base64Value>());
       expect((decode(elt, standardCodecs) as Base64Value).base64String,
           equals('AQID'));
@@ -428,17 +428,17 @@ void main() {
     });
 
     test('should accept <struct>', () {
-      final elt = parse('<struct></struct>').firstChild;
+      final elt = XmlDocument.parse('<struct></struct>').firstChild;
       expect(decode(elt, standardCodecs), equals({}));
     });
 
     test('should accept <array>', () {
-      final elt = parse('<array><data></data></array>').firstChild;
+      final elt = XmlDocument.parse('<array><data></data></array>').firstChild;
       expect(decode(elt, standardCodecs), equals([]));
     });
 
     test('throws on <unknown>', () {
-      final elt = parse('<unknown>1</unknown>').firstChild;
+      final elt = XmlDocument.parse('<unknown>1</unknown>').firstChild;
       expect(() => decode(elt, standardCodecs), throwsArgumentError);
     });
   });


### PR DESCRIPTION
@a14n 
Here is an attempt at #13 

The only breaking change is only accepting a `Uri` as a url. This mimics the change that was done for `package:http` which no longer accepts `Strings` in favor of `Uri`s. I think it is a reasonable breaking change to improve type safety and surface a `Uri.parse` error closer to user code.

Also, `parse` from `package:xml` was depreciated in favor of `XmlDocument.parse` so I updated those.

A lot of things have to be nullable for handling the null codec, but there aren't too many null assertion checks. All tests pass.

Thanks,
Tim